### PR TITLE
Fix DeepSeek V4 warmup on V2 runner

### DIFF
--- a/tests/model_executor/test_deepseek_v4_kernel_warmup.py
+++ b/tests/model_executor/test_deepseek_v4_kernel_warmup.py
@@ -3,6 +3,8 @@
 
 from types import SimpleNamespace
 
+import torch
+
 from vllm.model_executor.warmup import kernel_warmup
 
 
@@ -35,3 +37,49 @@ def test_deepseek_v4_mtp_uniform_decode_warmup_still_respects_limits():
         max_tokens=96,
         max_reqs=256,
     ) == (1, 2, 4, 8, 16, 24, 32)
+
+
+class _FakeV2BlockTables:
+    def __init__(self):
+        self.calls: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]] = []
+
+    def compute_slot_mappings(
+        self,
+        idx_mapping: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        positions: torch.Tensor,
+        num_tokens_padded: int,
+    ) -> torch.Tensor:
+        self.calls.append(
+            (
+                idx_mapping.clone(),
+                query_start_loc.clone(),
+                positions.clone(),
+                num_tokens_padded,
+            )
+        )
+        return torch.empty((1, num_tokens_padded), dtype=torch.int64)
+
+
+def test_deepseek_v4_slot_mapping_warmup_supports_v2_runner_without_input_batch():
+    block_tables = _FakeV2BlockTables()
+    runner = SimpleNamespace(
+        device=torch.device("cpu"),
+        max_num_tokens=4,
+        input_buffers=SimpleNamespace(
+            query_start_loc=torch.zeros(2, dtype=torch.int32),
+            positions=torch.full((4,), -1, dtype=torch.int64),
+        ),
+        block_tables=block_tables,
+    )
+
+    kernel_warmup._deepseek_v4_slot_mapping_warmup(runner)
+
+    assert block_tables.calls
+    idx_mapping, query_start_loc, positions, num_tokens_padded = next(
+        call for call in block_tables.calls if call[3] == 4
+    )
+    assert idx_mapping.tolist() == [0]
+    assert query_start_loc.tolist() == [0, 4]
+    assert positions.tolist() == [0, 1, 2, 3]
+    assert num_tokens_padded == 4

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -116,12 +116,13 @@ def _deepseek_v4_mtp_uniform_decode_warmup_requests(
     return tuple(reqs for reqs in candidates if reqs <= max_warmup_reqs)
 
 
-def _deepseek_v4_slot_mapping_warmup(runner: "GPUModelRunner") -> None:
-    max_tokens = getattr(runner, "max_num_tokens", 1)
-    block_table = runner.input_batch.block_table
-
+def _deepseek_v4_slot_mapping_warmup_v1(
+    runner: "GPUModelRunner",
+    max_tokens: int,
+) -> None:
     # Snapshot the runner buffers we mutate so warmup never leaks state into
     # the first real request.
+    block_table = runner.input_batch.block_table
     saved_query_start_loc_np: np.ndarray | None = None
     saved_query_start_loc_gpu: torch.Tensor | None = None
     if hasattr(runner, "query_start_loc"):
@@ -168,6 +169,66 @@ def _deepseek_v4_slot_mapping_warmup(runner: "GPUModelRunner") -> None:
             runner.query_start_loc.np[:2] = saved_query_start_loc_np
             assert saved_query_start_loc_gpu is not None
             runner.query_start_loc.gpu[:2].copy_(saved_query_start_loc_gpu)
+
+
+def _deepseek_v4_slot_mapping_warmup_v2(
+    runner: "GPUModelRunner",
+    max_tokens: int,
+) -> None:
+    block_tables = runner.block_tables
+    input_buffers = runner.input_buffers
+    query_start_loc_buffer = input_buffers.query_start_loc
+    positions_buffer = input_buffers.positions
+
+    max_warmup_tokens = _clamp_warmup_tokens(
+        max(_DEEPSEEK_V4_SLOT_MAPPING_WARMUP_TOKENS),
+        min(max_tokens, positions_buffer.shape[0]),
+    )
+    if max_warmup_tokens <= 0:
+        return
+
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=runner.device)
+    saved_query_start_loc = query_start_loc_buffer[:2].clone()
+    saved_positions = positions_buffer[:max_warmup_tokens].clone()
+
+    try:
+        for requested_tokens in _DEEPSEEK_V4_SLOT_MAPPING_WARMUP_TOKENS:
+            num_tokens = _clamp_warmup_tokens(requested_tokens, max_warmup_tokens)
+            if num_tokens <= 0:
+                continue
+
+            query_start_loc_buffer[0] = 0
+            query_start_loc_buffer[1] = num_tokens
+            positions = positions_buffer[:num_tokens]
+            positions.copy_(
+                torch.arange(num_tokens, dtype=torch.int64, device=runner.device)
+            )
+
+            block_tables.compute_slot_mappings(
+                idx_mapping,
+                query_start_loc_buffer[:2],
+                positions,
+                num_tokens_padded=num_tokens,
+            )
+    finally:
+        query_start_loc_buffer[:2].copy_(saved_query_start_loc)
+        positions_buffer[:max_warmup_tokens].copy_(saved_positions)
+
+
+def _deepseek_v4_slot_mapping_warmup(runner: "GPUModelRunner") -> None:
+    max_tokens = getattr(runner, "max_num_tokens", 1)
+    if hasattr(runner, "input_batch"):
+        _deepseek_v4_slot_mapping_warmup_v1(runner, max_tokens)
+        return
+
+    if hasattr(runner, "block_tables") and hasattr(runner, "input_buffers"):
+        _deepseek_v4_slot_mapping_warmup_v2(runner, max_tokens)
+        return
+
+    logger.debug(
+        "Skipping DeepSeek V4 slot mapping warmup because the model runner "
+        "does not expose V1 input_batch or V2 block_tables/input_buffers."
+    )
 
 
 def _deepseek_v4_structured_output_bitmask_warmup(


### PR DESCRIPTION
## What changed

- Fix DeepSeek V4 request-prep warmup for the V2 GPUModelRunner used by DSpark.
- Keep the existing V1 runner path intact and add a V2 path that warms slot mapping through block_tables/input_buffers.
- Add a regression test covering a V2-like runner that does not expose runner.input_batch.

## Root cause

DSpark uses the V2 GPUModelRunner, which does not have runner.input_batch. The sparse MLA request-prep warmup path still assumed the V1 runner layout and failed startup with AttributeError: GPUModelRunner object has no attribute input_batch.

## Duplicate-work check

- Checked issue 21 in yhfgyyf/vllm-deepseek-v4-sm89; existing workaround was to set VLLM_ENABLE_DEEPSEEK_V4_SPARSE_MLA_WARMUP=0.
- Checked open PRs in yhfgyyf/vllm-deepseek-v4-sm89 for DeepSeek V4 warmup / V2 runner / input_batch: none found.
- Checked open PRs in vllm-project/vllm for DeepSeek V4 warmup / V2 runner / input_batch: none found.

## Validation

- .venv/bin/python -m py_compile vllm/model_executor/warmup/kernel_warmup.py tests/model_executor/test_deepseek_v4_kernel_warmup.py
- git diff --check -- vllm/model_executor/warmup/kernel_warmup.py tests/model_executor/test_deepseek_v4_kernel_warmup.py
- Remote serve with VLLM_ENABLE_DEEPSEEK_V4_SPARSE_MLA_WARMUP unset returned /v1/models 200.
- Remote serving benchmarks after fix completed 10/10 for 8192/32768/131072 -> 1024.

## Not tested

- Local pytest collection is blocked in this checkout by vllm/_C.abi3.so torch ABI mismatch.

## AI assistance

AI assistance was used to diagnose, implement, test, and prepare this PR. The changed lines and validation evidence should be reviewed by the human maintainer before upstream submission.
