### PR TITLE
Make SM89 wheel versions reproducible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - 将 SM89 sparse MLA prefill/decode 切换到 FlashInfer 0.6.14 SM89 JIT fork，并为 release 增加匹配的 FlashInfer wheel。
 - Lightning Indexer scheduler metadata 改为按 `is_deep_gemm_supported()` 判断；安装了 DeepGEMM 包但硬件不支持的 SM89 不再调用其 metadata API。
+- wheel 构建脚本优先使用显式 `VLLM_VERSION_OVERRIDE`，自动推导时忽略历史 CUDA/SM Release tag，避免 `setuptools_scm` 在编译前解析失败。
 - 本次不更新 `confidence_head`，不包含 per-request adaptive ℓ，DSpark 固定使用 `ℓ=6`。
 - 4× RTX 4090、TP=4、单并发、每组 5 次全部成功。`8K / 32K / 128K -> 1K` 的 Prefill TPS 为 3515.72 / 4881.18 / 3812.00，Decode TPS 为 286.82 / 344.63 / 313.57。
 
@@ -13,6 +14,7 @@
 
 - Switched SM89 sparse MLA prefill/decode to the FlashInfer 0.6.14 SM89 JIT fork and added the matching FlashInfer wheel to the release.
 - Gated Lightning Indexer scheduler metadata with `is_deep_gemm_supported()` so SM89 does not call the metadata API merely because the DeepGEMM package is installed.
+- Made the wheel build script honor an explicit `VLLM_VERSION_OVERRIDE` and ignore historical CUDA/SM release tags during automatic version resolution, preventing a pre-build `setuptools_scm` parse failure.
 - Left `confidence_head` unchanged and excluded per-request adaptive ℓ; DSpark remains fixed at `ℓ=6`.
 - On 4× RTX 4090, TP=4, single concurrency, all five requests per case passed. For `8K / 32K / 128K -> 1K`, Prefill TPS is 3515.72 / 4881.18 / 3812.00 and Decode TPS is 286.82 / 344.63 / 313.57.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 - SM89 sparse MLA 的 prefill/decode 路径切换到 **FlashInfer 0.6.14 sparse MLA JIT fork**；release 同时提供匹配的 FlashInfer wheel，运行时会拒绝未包含 SM89 补丁的官方包。
 - 修复 Lightning Indexer 仅按“是否安装 DeepGEMM”生成 scheduler metadata 的问题；现在按当前 GPU 的实际 DeepGEMM 支持能力判断，SM89 无需卸载 DeepGEMM 环境即可避开不支持的 metadata 路径。
+- wheel 构建脚本会优先使用显式 `VLLM_VERSION_OVERRIDE`，自动推导版本时忽略历史 CUDA/SM Release tag，避免 `setuptools_scm` 在编译前解析失败。
 - 本次不更新 `confidence_head`，也不包含 per-request adaptive ℓ；DSpark 继续使用固定 `ℓ=6`。
 - 4× RTX 4090、TP=4、单并发、每组 5 次均 `5/5` 成功。`8K / 32K / 128K -> 1K` 的 Prefill TPS 为 **3515.72 / 4881.18 / 3812.00**，Decode TPS 为 **286.82 / 344.63 / 313.57**。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -13,6 +13,7 @@ It extends vLLM's **DeepSeek-V4-Flash** inference from SM90/SM100/SM120 to **SM8
 
 - Switched SM89 sparse MLA prefill/decode to the **FlashInfer 0.6.14 sparse MLA JIT fork**. The release includes the matching FlashInfer wheel, and runtime validation rejects an official package without the SM89 patch.
 - Fixed Lightning Indexer scheduler metadata selection to use actual DeepGEMM hardware support instead of package presence. An installed DeepGEMM package no longer makes SM89 call an unsupported metadata API.
+- The wheel build script now honors an explicit `VLLM_VERSION_OVERRIDE` and ignores historical CUDA/SM release tags during automatic version resolution, preventing a pre-build `setuptools_scm` parse failure.
 - This release does not update `confidence_head` and does not include per-request adaptive ℓ; DSpark remains fixed at `ℓ=6`.
 - On 4× RTX 4090, TP=4, single concurrency, all five requests per case passed. For `8K / 32K / 128K -> 1K`, Prefill TPS is **3515.72 / 4881.18 / 3812.00** and Decode TPS is **286.82 / 344.63 / 313.57**.
 

--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -8,13 +8,33 @@ export CUDA_HOME=/usr/local/cuda-13.0
 export PATH="$CUDA_HOME/bin:/home/yyf/.cargo/bin:$PATH"
 export VLLM_TARGET_DEVICE=cuda
 export VLLM_MAIN_CUDA_VERSION=13.0
-BASE_VERSION=$(.venv/bin/python setup.py --version)
-export VLLM_VERSION_OVERRIDE=${VLLM_VERSION_OVERRIDE:-${BASE_VERSION}.cu130}
+if [[ -z "${VLLM_VERSION_OVERRIDE:-}" ]]; then
+  BASE_VERSION=$(
+    .venv/bin/python <<'PY'
+from setuptools_scm import get_version
+
+print(
+    get_version(
+        root=".",
+        git_describe_command=(
+            "git describe --dirty --tags --long --match 'v[0-9]*' "
+            "--exclude '*-cu*' --exclude 'vtest'"
+        ),
+    )
+)
+PY
+  )
+  VERSION_SEPARATOR="+"
+  if [[ "$BASE_VERSION" == *+* ]]; then
+    VERSION_SEPARATOR="."
+  fi
+  export VLLM_VERSION_OVERRIDE="${BASE_VERSION}${VERSION_SEPARATOR}cu130"
+fi
 export TORCH_CUDA_ARCH_LIST="8.9+PTX"
 export MAX_JOBS=${MAX_JOBS:-16}
 export NVCC_THREADS=${NVCC_THREADS:-2}
 
-echo "=== START $(date +%T) | nvcc $(nvcc --version | tail -1) | arch=$TORCH_CUDA_ARCH_LIST ==="
+echo "=== START $(date +%T) | nvcc $(nvcc --version | tail -1) | arch=$TORCH_CUDA_ARCH_LIST | version=$VLLM_VERSION_OVERRIDE ==="
 .venv/bin/python -m build --wheel --no-isolation --outdir dist-sm89
 echo "=== END $(date +%T) ==="
 ls -lh dist-sm89/*.whl


### PR DESCRIPTION
## Why

Historical CUDA/SM release tags are intentionally descriptive but are not parseable by `setuptools_scm`. Because `build_wheel.sh` queried the source version before honoring `VLLM_VERSION_OVERRIDE`, a release build could fail before CUDA compilation.

## Changes

- Honor an explicit `VLLM_VERSION_OVERRIDE` without querying SCM first.
- Exclude historical `*-cu*` and `vtest` tags during automatic version resolution.
- Use a valid `+cu130` or `.cu130` separator based on the generated base version.
- Record the release-build fix in the Chinese and English changelogs.

This follow-up does not modify `confidence_head`, per-request adaptive l, FlashInfer runtime behavior, or inference kernels.

## Validation

- `bash -n build_wheel.sh`
- `git diff --check`
- `uvx --from pre-commit pre-commit run --files build_wheel.sh README.md README_EN.md CHANGELOG.md` (all hooks passed)
- Filtered SCM resolution: `0.23.1rc1.dev1017+g07d6cbf0e`
- Explicit override path: `9.9.9+test.cu130`

## Duplicate-work check

No open PR matched `build version release tag`; this fixes a release blocker discovered while packaging PR #24.

## AI assistance

OpenAI Codex assisted with the change. The maintainer requested, reviewed, and is responsible for the implementation and release.
