### PR TITLE
Fix Triton E8M0 block scale handling on CUDA

### DIFF
--- a/tests/kernels/quantization/test_block_fp8.py
+++ b/tests/kernels/quantization/test_block_fp8.py
@@ -153,6 +153,44 @@ def test_w8a8_block_fp8_matmul(M, N, K, block_size, out_dtype, seed):
     assert rel_diff < 0.001
 
 
+@torch.inference_mode()
+def test_w8a8_block_fp8_matmul_e8m0_scales():
+    # DeepSeek-V4-style checkpoints store block scales in exponent-only
+    # E8M0, which Triton cannot bind directly; the kernel upcasts them to
+    # fp32 before launch. Regression test for
+    # https://github.com/vllm-project/vllm/issues/47818.
+    M, N, K = 83, 512, 7168
+    block_size = [128, 128]
+    out_dtype = torch.bfloat16
+    torch.manual_seed(0)
+
+    fp8_info = torch.finfo(torch.float8_e4m3fn)
+    fp8_max, fp8_min = fp8_info.max, fp8_info.min
+
+    A_fp32 = (torch.rand(M, K, dtype=torch.float32) - 0.5) * 2 * fp8_max
+    A_fp8 = A_fp32.clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn)
+    B_fp32 = (torch.rand(N, K, dtype=torch.float32) - 0.5) * 2 * fp8_max
+    B_fp8 = B_fp32.clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn)
+
+    n_tiles = (N + block_size[0] - 1) // block_size[0]
+    k_tiles = (K + block_size[1] - 1) // block_size[1]
+
+    # Power-of-two scales round-trip E8M0 <-> fp32 exactly.
+    As = torch.exp2(torch.randint(-8, 0, (M, k_tiles)).to(torch.float32))
+    Bs = torch.exp2(torch.randint(-8, 0, (n_tiles, k_tiles)).to(torch.float32))
+
+    ref_out = w8a8_triton_block_scaled_mm(A_fp8, B_fp8, As, Bs, block_size, out_dtype)
+    out = w8a8_triton_block_scaled_mm(
+        A_fp8,
+        B_fp8,
+        As.to(torch.float8_e8m0fnu),
+        Bs.to(torch.float8_e8m0fnu),
+        block_size,
+        out_dtype,
+    )
+    assert torch.equal(out, ref_out)
+
+
 @pytest.mark.skipif(
     not current_platform.is_cuda(), reason="CUTLASS only supported on CUDA platform."
 )

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -915,14 +915,13 @@ def w8a8_triton_block_scaled_mm(
     assert len(block_size) == 2
     block_n, block_k = block_size[0], block_size[1]
 
-    # Triton cannot currently bind E8M0 scale tensors directly. On ROCm,
+    # Triton cannot currently bind E8M0 scale tensors directly.
     # DeepSeek-V4 checkpoints store block scales in exponent-only E8M0 format,
     # so decode them to fp32 before launching the kernel.
-    if current_platform.is_rocm() or current_platform.is_xpu():
-        if As.dtype == torch.float8_e8m0fnu:
-            As = _upcast_e8m0_to_fp32(As).contiguous()
-        if Bs.dtype == torch.float8_e8m0fnu:
-            Bs = _upcast_e8m0_to_fp32(Bs).contiguous()
+    if As.dtype == torch.float8_e8m0fnu:
+        As = _upcast_e8m0_to_fp32(As).contiguous()
+    if Bs.dtype == torch.float8_e8m0fnu:
+        Bs = _upcast_e8m0_to_fp32(Bs).contiguous()
 
     assert A.shape[-1] == B.shape[-1]
     assert A.shape[:-1] == As.shape[:-1] and A.is_contiguous()


### PR DESCRIPTION
## What

Fix E8M0 block scales on the CUDA Triton W8A8 block-FP8 path by decoding
them to contiguous FP32 tensors before the Triton launch. Add the focused
regression test from upstream vLLM PR #47988.

Fixes #34.

## Root cause

DeepSeek-V4 stores block scales as `torch.float8_e8m0fnu`. The existing
conversion was gated to ROCm/XPU, so CUDA passed that dtype into Triton's
JIT binder, which does not canonicalize it and raises
`KeyError: 'float8_e8m0fnu'` during the profile run.

## Scope

- Apply the PR #47988 Triton hunk to both activation and weight scales.
- Add the E8M0-versus-FP32 output-equivalence regression test.
- Deliberately exclude the PR's unrelated CUTLASS/SM120 changes.

## Duplicate-work check

No open PR in this fork references Issue #34, `float8_e8m0fnu`, or the E8M0
Triton block-scale fix. Upstream PR #47988 is still a draft; this PR is the
narrow fork backport needed for the affected SM89 release.

## Validation

- Pre-fix fork commit `8aba6ae7e`: reproduced
  `KeyError: 'float8_e8m0fnu'` with the exact E8M0 wrapper path.
- Local SM120: targeted pytest passed (`1 passed, 472 deselected`).
- Clean fork-main worktree: targeted pytest passed; Ruff check/format,
  syntax compilation, and `git diff --check` passed.
- Remote 4x RTX 4090 / SM89: direct upstream-equivalent regression passed;
  E8M0 and FP32 scale outputs were exactly equal (`max_abs_diff=0.0`).
  The upstream pytest module skips capability below SM90, so this direct CUDA
  run—not the skipped pytest—is the SM89 regression evidence.
- Remote full 4x RTX 4090 serve: selected the Triton block-FP8 kernel,
  completed the profile run, KV-cache initialization, and CUDA graph capture,
  reached `Application startup complete`, and returned HTTP 200 from a real
  `/v1/completions` request. Final log counts: zero KeyErrors, tracebacks, or
  ERROR lines.

## AI assistance

AI assistance was used to investigate, port, and test this change. Before
marking the PR ready, the human submitter must review every changed line,
understand and defend the fix end-to-end, and rerun the relevant tests.

Upstream reference: https://github.com/vllm-project/vllm/pull/47988
