### PR TITLE
Fix int32 overflow in SM89 paged MQA logits block addressing

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/ops/sm12x_mqa.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/sm12x_mqa.py
@@ -272,7 +272,7 @@ def _fp8_paged_mqa_logits_kernel(
         + block_rank[None, :] * stride_btk,
         mask=valid_m[:, None] & valid_n[None, :],
         other=0,
-    )
+    ).to(tl.int64)
 
     logits = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
     scale = tl.load(
@@ -397,7 +397,7 @@ def _fp8_paged_mqa_logits_rowwise_kernel(
         block_tables_ptr + batch * stride_btb + block_rank * stride_btk,
         mask=valid_row & context_mask,
         other=0,
-    )
+    ).to(tl.int64)
 
     scale = tl.load(
         scale_ptr + block_idx * stride_sb + block_offset * stride_ss,


### PR DESCRIPTION
### 问题

在 SM89（如 8x L20，TP=8）上，DeepSeek-V4-Flash 开启 prefix caching 时会触发 `CUDA error: an illegal memory access was encountered`。

### 根因

`vllm/models/deepseek_v4/nvidia/ops/sm12x_mqa.py` 中的 paged MQA logits Triton 内核把 `block_idx` 按 **int32** 加载，再计算 `block_idx * stride_kvb`（以及 `block_idx * stride_sb`）。统一 KV pool 的每层块步长很大（TP=8 时约 100 万元素），一旦池中块数超过约 2k 块（长上下文或多并发请求，prefix caching 会让这种场景很常见），int32 乘法就超过 `2^31` **溢出成负数偏移**：

- 地址未映射 → **illegal memory access**；
- 地址恰好已映射 → **静默算错 logits**（输出乱码）。

### 修复

在两个内核中把 `block_idx` 相乘前强转为 `tl.int64`。与上游 vLLM 对同款内核 `mqa_logits_triton.py` 的修复（commit `5201cdf4595f`）一致。

### 验证

- 仅改 1 个文件，+2/-2 行。
- 此前必崩的场景（长上下文 + prefix caching）修复后可正常运行。
- 相关讨论：issue #46。

---

# 备注 / Notes

- 类型：Bug fix
- 涉及文件：`vllm/models/deepseek_v4/nvidia/ops/sm12x_mqa.py`
- 关联：`vllm-project/vllm` commit `5201cdf4595f`；本仓库 issue #46