### PR TITLE
perf(sm80): avoid long-context MQA register spills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+/.repro/
 env/
 venv/
 ENV/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ Decode 侧结果如下，基线为同一服务器上无 DSpark 的 `mbt16k` 结�
 | 8,192 -> 1,024 | 1 | **229.8 tok/s/req** | 57.6 tok/s/req | **3.99×** |
 | 32,768 -> 1,024 | 1 | **274.2 tok/s/req** | 58.1 tok/s/req | **4.72×** |
 
+### 本次长上下文补丁的边界
+
+本分支把 SM80 长序列 FP8 MQA logits 的 query tile 固定为 `BLOCK_M=16`，避免
+`BLOCK_M=64` 在 A100 上产生严重的寄存器溢出。它只修复 Lightning Indexer 的
+长上下文 prefill 热点，不包含 CPU/NUMA MoE offload、DSpark 参数、服务编排或 API
+聚合层。
+
+下面分别给出两条复现路线：
+
+- **源码路线**：构建本仓库，适合已有足够模型运行资源的 SM80 / SM86 / SM89 环境。
+- **已验证的 2×A100 混合路线**：使用 `Lvllmds4-x v2.3.9` 的 CPU MoE offload，
+  再应用本分支等价的 M16 改动和第 6.2 节列出的正确性回移。
+
+仅拉取这个性能 PR **不能单独复刻**第二条路线的完整运行环境。文档会明确区分本
+PR、公开运行时和正确性补丁，避免把部署改造误写成本 PR 的能力。
+
 ---
 
 ## 1. 背景:为什么需要这个 fork
@@ -60,7 +76,7 @@ DeepSeek-V4-Flash 用了 DeepSeek 稀疏注意力(DSA / Lightning Indexer)+ FP4 
 |---|---|
 | 适配 GPU | **SM80**(A100), **SM86**(RTX 3090 / A10 / A40), **SM89**(RTX 4090 / L40 / L40S / L4 / RTX 6000 Ada) |
 | 驱动 / CUDA toolkit | 595.x / **CUDA 13.0**(wheel 构建使用 `/usr/local/cuda-13.0`, nvcc 13.0.48) |
-| Python | 3.12(conda) |
+| Python | 3.12(历史验证使用 conda；下文用 uv 创建隔离环境) |
 | torch | **2.11.0+cu130** |
 | vLLM | 本 fork = **0.23.1rc1.dev145**(DeepSeek-V4-Flash + SM80 / SM86 / SM89 改动)，源码编译 |
 
@@ -68,12 +84,10 @@ DeepSeek-V4-Flash 用了 DeepSeek 稀疏注意力(DSA / Lightning Indexer)+ FP4 
 
 ## 3. 源码安装(clone 本仓库编译)
 
-### 3.1 conda 环境 + torch
+### 3.1 前置工具
 
-```bash
-conda create -n ds python=3.12 -y && conda activate ds
-uv pip install torch==2.11.0 --index-url https://download.pytorch.org/whl/cu130
-```
+确保主机已经安装 Git、uv、Rust 1.95 和匹配的 CUDA toolkit。仓库内隔离环境在 clone
+之后创建，避免把 `.venv` 建到错误目录。
 
 ### 3.2 Rust 工具链(vLLM 构建需要 Rust frontend)
 
@@ -91,10 +105,23 @@ source "$HOME/.cargo/env"
 ### 3.3 clone 本仓库
 
 ```bash
-git clone https://github.com/yhfgyyf/vllm-deepseek-v4-sm80-sm86-sm89.git
-cd vllm-deepseek-v4-sm80-sm86-sm89
-git checkout sm80-deepseek-v4-flash
+git clone https://github.com/yhfgyyf/vllm-deepseek-v4-sm89.git
+cd vllm-deepseek-v4-sm89
+git fetch https://github.com/fidonan/vllm-deepseek-v4-sm89.git \
+  perf/sm80-long-context-mqa-block-m
+git checkout -B perf-sm80-long-context-mqa-block-m FETCH_HEAD
+git rev-parse HEAD
+uv venv --python 3.12
+source .venv/bin/activate
+uv pip install torch==2.11.0 --index-url https://download.pytorch.org/whl/cu130
 ```
+
+上面的公开 head 分支用于在合并前精确复现本改动；合并后应改为维护者最终合入的 branch/tag
+和 commit。请固定并保存输出的 commit。当前 SM80 基线尚未包含已经合入 `main` 的
+[PR #51](https://github.com/yhfgyyf/vllm-deepseek-v4-sm89/pull/51)；长上下文部署前还要
+同步这项 paged-MQA 64 位寻址修复。当前单提交为
+`3183db2f6c86803cc86d06223000d220e001baf8`；先用 `git merge-base --is-ancestor`
+检查目标 revision，未包含时再审查并 cherry-pick，不要重复应用。
 
 ### 3.4 编译
 
@@ -141,12 +168,25 @@ uv pip install dist/vllm-*.whl --extra-index-url https://download.pytorch.org/wh
 
 ## 5. 算子级自检(无需起完整模型)
 
+安装后先运行仓库自带的测试：
+
+```bash
+uv pip install -r requirements/test/cuda.txt \
+  --extra-index-url https://download.pytorch.org/whl/cu130 \
+  --index-strategy unsafe-best-match
+.venv/bin/python test_sm80_ops.py
+.venv/bin/python -m pytest -q tests/v1/attention/test_sm120_deepgemm_fallbacks.py
+```
+
+最后一条命令包含长序列 `BLOCK_M=16` 选择测试；在 SM80 上还会比较 M16 与 M64 的
+完整 logits，并要求逐元素一致。
+
 ```python
 import torch
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.mla import sparse_mla_env as e
 print("cap:", current_platform.get_device_capability())          # (8, 9)
-print("is_ada_sm89:", e.is_ada_sm89())                            # True
+print("is_ampere_or_ada:", e.is_ampere_or_ada())                 # True on SM8x
 print("triton sparse mla:", e.is_triton_sparse_mla_enabled(torch.device("cuda:0")))  # True
 from vllm.model_executor.layers.sparse_attn_indexer import _sparse_indexer_requires_deep_gemm as r
 print("indexer needs deepgemm (fp8 cache):", r(False))           # False ← 关键
@@ -156,13 +196,20 @@ print("has_cutedsl:", has_cutedsl())                             # False on SM89
 
 ---
 
-## 6. 部署(vllm serve)
+## 6. 可复现部署
+
+### 6.1 本仓库源码路线
+
+以下命令使用公开的 DSpark 模型 ID，不写入机器路径、监听地址或凭据。`TP_SIZE` 应由
+部署者按实际可用 GPU 数设置。
 
 ```bash
+export MODEL_ID=deepseek-ai/DeepSeek-V4-Flash-DSpark
+export TP_SIZE="${TP_SIZE:?set TP_SIZE to the number of selected GPUs}"
 export VLLM_TRITON_MLA_SPARSE=1
-vllm serve /path/to/DeepSeek-V4-Flash \
+.venv/bin/vllm serve "$MODEL_ID" \
   --served-model-name deepseek-v4-flash \
-  --tensor-parallel-size 4 \
+  --tensor-parallel-size "$TP_SIZE" \
   --kv-cache-dtype fp8_ds_mla \
   --block-size 256 \
   --max-model-len 262144 \
@@ -170,24 +217,174 @@ vllm serve /path/to/DeepSeek-V4-Flash \
   --max-num-seqs 16 \
   --reasoning-parser deepseek_v4 \
   --enable-auto-tool-choice --tool-call-parser deepseek_v4 \
-  --trust-remote-code --port 8000
+  --trust-remote-code
 ```
-
 
 启动成功标志:`Application startup complete.`，日志里能看到 `Using 'MARLIN' Mxfp4 MoE backend` / `Using FP8 indexer cache`。
 
+### 6.2 已验证的 2×A100 混合路线
+
+这条路线用于两张 80 GiB A100 无法把全部 MoE 专家常驻显存的场景。实测使用的运行时为
+[Lvllmds4-x v2.3.9](https://github.com/guqiong96/Lvllmds4-x/releases/tag/lvllmds4-x-v2.3.9)，
+资产名为 `lvllmds4_x-2.3.9-cp312-cp312-manylinux_2_34_x86_64.whl`，要求 x86_64、
+Python 3.12 和 glibc 2.34 或更新版本；SHA-256 为
+`1357dd5e11d060cce973f84563d96bb18c1bd2bd7a4d05f642fe01629ba7ab62`。
+
+```bash
+export LVLLM_REPRO_DIR=.repro/lvllmds4x
+mkdir -p "$LVLLM_REPRO_DIR"
+uv venv --python 3.12 "$LVLLM_REPRO_DIR/.venv"
+export LVLLM_WHEEL=lvllmds4_x-2.3.9-cp312-cp312-manylinux_2_34_x86_64.whl
+export LVLLM_WHEEL_URL=https://github.com/guqiong96/Lvllmds4-x/releases/download/lvllmds4-x-v2.3.9/$LVLLM_WHEEL
+curl -fL "$LVLLM_WHEEL_URL" -o "$LVLLM_REPRO_DIR/$LVLLM_WHEEL"
+printf '%s  %s\n' \
+  1357dd5e11d060cce973f84563d96bb18c1bd2bd7a4d05f642fe01629ba7ab62 \
+  "$LVLLM_REPRO_DIR/$LVLLM_WHEEL" | sha256sum -c -
+uv pip install --python "$LVLLM_REPRO_DIR/.venv/bin/python" \
+  "$LVLLM_REPRO_DIR/$LVLLM_WHEEL"
+```
+
+在启动前必须完成四项检查：
+
+1. 在隔离环境安装并校验上面的公开 wheel；不要覆盖已有 vLLM 环境。
+   `.repro/` 已被仓库忽略，完成后应清理；不要提交 wheel 或环境文件。
+2. 将本分支 `_fp8_mqa_logits_block_m()` 的 M16 改动应用到该隔离运行时。第 5 节测试
+   只验证源码路线，不能用来证明 wheel 已被修改；应在仓库目录之外用 hybrid interpreter
+   导入 `vllm`，检查 `vllm.__file__`、目标函数源码和 SM80 长序列返回值，再运行同等的
+   GPU 等价测试。若导入路径落到源码 checkout，立即停止。
+
+   ```bash
+   set -euo pipefail
+   export LVLLM_REPRO_DIR="${LVLLM_REPRO_DIR:-.repro/lvllmds4x}"
+   REPRO_ROOT="$(pwd -P)"
+   CHECK_DIR="$(mktemp -d)"
+   (
+     cd "$CHECK_DIR"
+     "$REPRO_ROOT/$LVLLM_REPRO_DIR/.venv/bin/python" - <<'PY'
+   import inspect
+   import vllm
+   from vllm.models.deepseek_v4.nvidia.ops import sm12x_mqa
+
+   print(vllm.__file__)
+   print(inspect.getsource(sm12x_mqa._fp8_mqa_logits_block_m))
+   assert sm12x_mqa._fp8_mqa_logits_block_m(4096, 16 * 1024 + 1) == 16
+   PY
+     "$REPRO_ROOT/$LVLLM_REPRO_DIR/.venv/bin/python" \
+       "$REPRO_ROOT/benchmarks/kernels/benchmark_sm12x_mqa.py" \
+       --contexts 98304 --repeats 1 --seed 0
+   )
+   rmdir "$CHECK_DIR"
+   ```
+3. 确认运行时含有 [paged-MQA 64 位寻址修复](https://github.com/yhfgyyf/vllm-deepseek-v4-sm89/pull/51)，
+   以及上游 vLLM 的 mixed-precision/packed KV zeroing 修复：
+   [#47574](https://github.com/vllm-project/vllm/pull/47574)、
+   [#49623](https://github.com/vllm-project/vllm/pull/49623)、
+   [#49704](https://github.com/vllm-project/vllm/pull/49704)、
+   [#49903](https://github.com/vllm-project/vllm/pull/49903)、
+   [#50276](https://github.com/vllm-project/vllm/pull/50276) 和
+   [#52058](https://github.com/vllm-project/vllm/pull/52058)。
+   长期运行还应包含 scheduler 每步 drain 修复
+   [#44490](https://github.com/vllm-project/vllm/pull/44490)。
+4. CPU 必须为 x86_64 且支持 AVX2；宿主需提供 NUMA runtime，隔离环境的 libstdc++
+   也必须满足 wheel 的 GLIBCXX ABI。若 uv 环境 import 报 GLIBCXX 错误，应换用满足
+   ABI 的宿主工具链、兼容容器或 Conda 环境，不要就地替换系统库。
+
+这些正确性回移与本性能 PR 是相互独立的。实测栈使用了与这些上游修复等价的本地回移；
+文档列出的是基准完成后上游收敛的推荐修复集合，并未把该集合重新作为整体跑完同一轮
+端到端 A/B。由于这些跨版本回移仍需按目标 revision 解决冲突和复测，本节是已验证配置
+清单，不宣称是一条无需审查的自动安装脚本。缺少这些修复时，可以做隔离 kernel 实验，
+但不要把超长上下文结果当作长期运行稳定性结论。
+
+下面是当前推荐复现的运行参数，不等同于第 7.5 节每个历史样本的逐项配置。
+`GPU_DEVICES` 由部署者传入，必须同时检查 GPU interconnect 拓扑和 CPU/NUMA affinity
+后选择同一高速互联组；线程数和常驻层不是通用最优值，应在显存、主存和带宽检查通过
+后再使用。
+
+```bash
+export MODEL_ID=deepseek-ai/DeepSeek-V4-Flash-DSpark
+export CUDA_DEVICE_ORDER=PCI_BUS_ID
+export CUDA_VISIBLE_DEVICES="${GPU_DEVICES:?set the selected GPU IDs}"
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export LVLLM_MOE_NUMA_ENABLED=1
+export LK_THREADS=30
+export OMP_NUM_THREADS=30
+export LK_THREAD_BINDING=CPU_CORE
+export LVLLM_GPU_PREFETCH_WINDOW=1
+export LVLLM_GPU_PREFILL_MIN_BATCH_SIZE=256
+export LK_POWER_SAVING=0
+export LVLLM_GPU_RESIDENT_MOE_LAYERS=0-28
+
+.repro/lvllmds4x/.venv/bin/vllm serve "$MODEL_ID" \
+  --served-model-name deepseek-v4-flash \
+  --tensor-parallel-size 2 \
+  --max-model-len 262144 \
+  --gpu-memory-utilization 0.95 \
+  --trust-remote-code \
+  --compilation_config.cudagraph_mode FULL_DECODE_ONLY \
+  --enable-prefix-caching \
+  --enable-chunked-prefill \
+  --max-num-batched-tokens 8192 \
+  --dtype bfloat16 \
+  --max-num-seqs 2 \
+  --enable-auto-tool-choice \
+  --kv-cache-dtype fp8_ds_mla \
+  --block-size 256 \
+  --tokenizer-mode deepseek_v4 \
+  --tool-call-parser deepseek_v4 \
+  --reasoning-parser deepseek_v4 \
+  --default-chat-template-kwargs '{"enable_thinking": true}' \
+  --speculative-config \
+    '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic"}' \
+  --disable-custom-all-reduce
+```
+
+实测环境设置过 `FLASHINFER_DISABLE_VERSION_CHECK=1`。这会绕过版本保护，不应作为通用
+默认值；只有在核对 wheel release 的 FlashInfer 版本和二进制 ABI 后，才能为兼容该固定
+运行时显式设置。
+
+`LVLLM_*` 和 `LK_*` 是 Lvllmds4-x 专用开关，不适用于普通 vLLM。本配置启动阶段需要
+完成权重加载、KV 初始化、sparse MLA warmup 和 Triton/CUDA graph 编译；只有服务健康、
+无 worker 重启且两个 rank 都完成 warmup 后才能开始正式测试。
+
+### 6.3 交给 Codex 的复现任务
+
+可以把下面这段直接交给 Codex。它要求 Codex 自己发现设备和目录，并禁止把发现到的
+机器信息写回仓库：
+
+```text
+Read AGENTS.md and both README files completely before acting.
+Reproduce the SM80 long-context MQA M16 result in an isolated environment.
+
+1. Inspect GPU capability, topology, NUMA layout, free RAM, disk capacity, CUDA,
+   Python, and the currently selected Git revision. Do not change running services.
+2. Choose either the source-only route or the documented Lvllmds4-x hybrid route.
+   Stop and report if the machine cannot hold the model and runtime state.
+3. Pin every repository revision and verify every downloaded artifact checksum.
+4. Verify the paged-MQA int64 addressing fix and every listed packed/mixed-KV
+   zeroing fix before treating a long-context run as a stability test.
+5. Apply only this branch's M16 selector change, then run the focused unit and
+   GPU-equivalence tests. Do not add Router, protocol, API, or service-manager code.
+6. Start the model in the foreground using endpoint and credentials supplied by
+   the operator. Never invent or commit an address, port, username, absolute local
+   path, credential, service name, prompt, or production log.
+7. Warm each new Triton shape with a throwaway unique prefix. Benchmark another
+   unique prefix at concurrency one, verify zero prefix-cache hits, and save the
+   exact commit, parameters, JIT state, token counts, TTFT, and kernel timing.
+8. Return a sanitized report and leave generated machine-specific files untracked.
+```
+
 ---
 
-## 7. 测试结果(4× RTX 4090)
+## 7. 测试结果
 
-### 7.1 推理正确性
+### 7.1 推理正确性(4× RTX 4090 源码路线)
 ```
 Q: 用一句话介绍长城。
 A: 长城是中国古代为抵御北方游牧民族入侵而修筑的、横跨多个朝代、绵延数千公里的
    军事防御工程，也是世界文化遗产中象征中华民族坚韧精神的伟大奇迹。   (finish_reason=stop)
 ```
 
-### 7.2 最大上下文(KV cache)
+### 7.2 最大上下文(4× RTX 4090 源码路线)
 | max-model-len | max-num-seqs | GMU | GPU KV cache | 单请求并发 | 启动 |
 |---|---|---|---|---|---|
 | 262,144 (256K) | 16 | 0.97 | 972,374 tok | 3.71x | ✅ |
@@ -195,8 +392,6 @@ A: 长城是中国古代为抵御北方游牧民族入侵而修筑的、横跨�
 | **1,048,576 (1M)** | 4 | 0.97 | **1,243,644 tok** | 1.19x | ✅(模型架构上限) |
 
 实测能跑完的最长输入:**768K(786,000 token，prefill ~147s)**。1M 可启动、kernel 数值正确，但**满 1M 单次 prefill 极慢(>10 min)，不实用**。日常推荐 **128K~256K**。
-
-输入长度 sweep(256K 配置，均成功):64K(25s)/128K(37s)/200K(74s)/262K(71s)。
 
 ### 7.3 SM80/A800 DSpark decode 性能(单并发，输出 1,024 token)
 | 输入 | DSpark decode | 无 DSpark decode | decode 提升 |
@@ -206,7 +401,95 @@ A: 长城是中国古代为抵御北方游牧民族入侵而修筑的、横跨�
 
 SM80/A800 仍是测试性适配。这里仅列 decode 结果，长上下文 prefill 仍需单独评估。
 
-### 7.4 Tool call(`deepseek_v4` parser)
+### 7.4 SM80/A100 长上下文 MQA kernel A/B
+
+这是本补丁的历史 kernel A/B 记录：同一进程、同一输入，每种 `BLOCK_M` 独立编译；编译后
+先执行一次不计时 warmup，再用 CUDA event 计时 3 次取中位数。`M` 随 `N` 调整，使
+FP32 logits workspace 约为 256 MiB。固定 `num_heads=64`、`head_dim=128`；三行的
+`M` 分别为 2,730、2,048、1,724，输入为 FP8 E4M3 Q/K、FP32 scale/weights。公开
+同 shape 复测脚本默认随机 seed 为 0；历史表使用按上下文派生的固定 seed，因此它用来
+复核性能趋势和数值等价，不保证逐毫秒复刻历史表。第 5 节的轻量等价测试不复现这些
+计时 shape。
+
+公开复测脚本为
+[`benchmarks/kernels/benchmark_sm12x_mqa.py`](benchmarks/kernels/benchmark_sm12x_mqa.py)；
+它会拒绝非 SM80 设备，并输出各 shape 的 CUDA-event 中位数和 M16/M64 等价性结果。
+寄存器 spill 数来自当次 Triton 编译产物元数据，表中的值属于历史编译环境，不能视为
+跨 Triton/CUDA 版本恒定值。
+
+```bash
+.venv/bin/python benchmarks/kernels/benchmark_sm12x_mqa.py \
+  --contexts 98304 131072 155648 \
+  --repeats 3 \
+  --seed 0 \
+  --output-json mqa-kernel-results.json
+```
+
+| 原始上下文 | C4 压缩后 N | M16 | M64 | kernel 加速 | M16 / M64 spill |
+|---:|---:|---:|---:|---:|---:|
+| 98,304 | 24,576 | **40.491 ms** | 643.797 ms | **15.90×** | 0 / 5,744 B/thread |
+| 131,072 | 32,768 | **34.065 ms** | 1,003.002 ms | **29.44×** | 0 / 8,272 B/thread |
+| 155,648 | 38,912 | **34.547 ms** | 644.409 ms | **18.65×** | 0 / 5,744 B/thread |
+
+三组约 256 MiB 的完整 FP32 logits 都满足 `torch.equal(M16, M64)`，没有 NaN/Inf 差异。
+这里的毫秒数是单个 MQA kernel latency，**不是** TTFT 或端到端 prefill tok/s。
+
+### 7.5 SM80/A100 端到端观测
+
+以下是已经实际执行过的单并发样本；prefill 速度按 `prompt tokens / client TTFT` 计算。
+M16 正式样本使用全新 token 序列、prefix-cache 命中为 0，且该 shape 的 JIT 已预热。
+
+| 上下文 | 选择器 / 状态 | client TTFT | 观测 prefill |
+|---:|---|---:|---:|
+| 65,536 | 原选择器已使用 M16；JIT-hot 边界对照 | 29.893 s | **2,192.4 tok/s** |
+| 98,304 | 原选择器 M64；cold prefix | 237.989 s | 413.1 tok/s |
+| 98,304 | M16；首次 shape/JIT | 105.971 s | 927.6 tok/s |
+| 98,304 | M16；JIT-hot、cold prefix | 54.383 s | **1,807.6 tok/s** |
+| 155,648 | 原选择器 M64；cold prefix | 730.664 s | 213.0 tok/s |
+| 155,648 | M16；首次 shape/JIT | 138.660 s | 1,122.5 tok/s |
+| 155,648 | M16；JIT-hot、cold prefix | 110.015 s | **1,414.8 tok/s** |
+
+这些端到端数据是 `n=1` 的运行观测，不是严格的同配置 A/B：旧基线使用
+`max-num-batched-tokens=16384`、常驻层 `0-27`；M16 样本使用 `8192`、GMU `0.90`、
+常驻层 `0-28`，并使用独立编译缓存。65,536 正好映射到 C4 的 16,384 边界，旧代码本来就选
+M16，因此只能作为控制样本。没有执行过补丁后的 131,072 全服务 cold-prefill，本文不
+提供该长度的端到端速度或插值结果。
+
+复测时不要使用内置 warmup 请求复用正式 prompt。应先以 seed A 独立发送一次相同长度
+的 JIT priming 请求，再以 seed B 启动正式单请求测试；两次都关闭 request warmup 和
+ready check。正式结果必须同时满足：保存的 `input_lens` 等于目标长度、metrics 显示
+cache-hit 增量为 0、请求窗口没有新 JIT 日志。`input_lens[0] / ttfts[0]` 才是本表使用的
+client-observed TTFT rate，而不是服务端 `request_prefill_time`。
+
+下面以混合路线为例；源码路线把 `BENCH_VLLM` 指向 `.venv/bin/vllm`。
+
+```bash
+export BENCH_VLLM=.repro/lvllmds4x/.venv/bin/vllm
+"$BENCH_VLLM" bench serve \
+  --backend openai \
+  --base-url "${BENCH_BASE_URL:?set the operator-provided endpoint}" \
+  --endpoint /v1/completions \
+  --model deepseek-v4-flash \
+  --tokenizer deepseek-ai/DeepSeek-V4-Flash-DSpark \
+  --tokenizer-mode deepseek_v4 \
+  --dataset-name random \
+  --random-input-len "${BENCH_TOKENS:?set the measured input length}" \
+  --random-output-len 32 \
+  --random-range-ratio 0 \
+  --num-prompts 1 \
+  --max-concurrency 1 \
+  --request-rate inf \
+  --num-warmups 0 \
+  --ready-check-timeout-sec 0 \
+  --seed "${BENCH_SEED:?use a seed different from the priming request}" \
+  --temperature 0 \
+  --save-result \
+  --save-detailed \
+  --result-dir "${BENCH_RESULT_DIR:?set an isolated result directory}" \
+  --result-filename measured.json
+```
+
+### 7.6 Tool call(`deepseek_v4` parser)
 ```
 Q: 北京今天天气怎么样？请用摄氏度回答。  (tools=[get_weather])
 → finish_reason: tool_calls
@@ -220,7 +503,14 @@ Q: 北京今天天气怎么样？请用摄氏度回答。  (tools=[get_weather])
 1. **MoE 走 Marlin**:正确性已验证，但性能比原生 FP4 MMA 低。性能调优空间最大的一块。
 2. **性能未针对 4090 调优**:fused_moe / scaled_mm 的 tuned config 只覆盖 RTX PRO 6000 / GB10，4090 用默认 heuristic(日志会有 "Performance might be sub-optimal" 提示)。
 3. **超长上下文**:1M 可启动但 prefill 慢到不实用;>256K 单请求约数分钟。
-4. 仅在 4× RTX 4090 验证过;其它 Ada 卡(L40/L4 等)原理相同但未实测。
+4. 4× RTX 4090 源码路线、4× A800 DSpark decode 和 2× A100 混合路线分别有本文标注
+   的测试；其它 Ada 卡(L40/L4 等)原理相同但未实测。
+5. **M16 只优化 prefill**：paged decode 不调用这个非 paged MQA 路径；decode 吞吐仍由
+   长上下文 attention、MoE offload 和 DSpark 接受率共同决定。
+6. **部署依赖边界**：本 PR 不包含 paged-MQA 寻址和 packed/mixed-KV zeroing 回移；
+   未核对第 6.2 节正确性前置项时，不应声称已经复现完整稳定环境。
+7. **基准边界**：首次新 shape 包含 JIT 成本，exact-repeat 会命中 prefix cache。两者都
+   不能替代“JIT 已热 + 新 prefix + cache hit 为 0”的正式 cold-prefill 样本。
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -23,6 +23,26 @@ Decode-side results below use the same server's `mbt16k` no-DSpark run as baseli
 | 8,192 -> 1,024 | 1 | **229.8 tok/s/req** | 57.6 tok/s/req | **3.99×** |
 | 32,768 -> 1,024 | 1 | **274.2 tok/s/req** | 58.1 tok/s/req | **4.72×** |
 
+### Scope of the long-context patch
+
+This branch fixes the FP8 MQA-logits query tile at `BLOCK_M=16` for long SM80
+sequences, avoiding the severe register spill produced by `BLOCK_M=64` on A100.
+It only addresses the long-context Lightning Indexer prefill hotspot. It does not
+provide CPU/NUMA MoE offload, DSpark tuning, service orchestration, or an API
+aggregation layer.
+
+This document provides two separate reproduction routes:
+
+- **Source route:** build this repository on an SM80 / SM86 / SM89 system with
+  sufficient resources for the model.
+- **Validated 2×A100 hybrid route:** use CPU MoE offload from `Lvllmds4-x v2.3.9`,
+  then apply the equivalent M16 change and the correctness backports listed in
+  Section 6.2.
+
+Pulling this performance PR alone does **not** recreate the complete second route.
+The documentation keeps the PR, public runtime, and correctness patches separate
+to avoid attributing deployment changes to this PR.
+
 ---
 
 ## 1. Background: why this fork
@@ -61,7 +81,7 @@ DeepSeek-V4-Flash combines DeepSeek Sparse Attention (DSA / Lightning Indexer) +
 |---|---|
 | Supported GPUs | **SM80** (A100), **SM86** (RTX 3090 / A10 / A40), **SM89** (RTX 4090 / L40 / L40S / L4 / RTX 6000 Ada) |
 | Driver / CUDA toolkit | 595.x / **CUDA 13.0** (wheel built with `/usr/local/cuda-13.0`, nvcc 13.0.48) |
-| Python | 3.12 (conda) |
+| Python | 3.12 (historical validation used conda; uv is used below) |
 | torch | **2.11.0+cu130** |
 | vLLM | this fork = **0.23.1rc1.dev145** (DeepSeek-V4-Flash + SM80 / SM86 / SM89 changes), built from source |
 
@@ -69,12 +89,10 @@ DeepSeek-V4-Flash combines DeepSeek Sparse Attention (DSA / Lightning Indexer) +
 
 ## 3. Build from source (clone this repo)
 
-### 3.1 Conda env + torch
+### 3.1 Prerequisites
 
-```bash
-conda create -n ds python=3.12 -y && conda activate ds
-uv pip install torch==2.11.0 --index-url https://download.pytorch.org/whl/cu130
-```
+Install Git, uv, Rust 1.95, and a matching CUDA toolkit first. The repository-local
+environment is created after clone so `.venv` cannot be placed in the wrong directory.
 
 ### 3.2 Rust toolchain (vLLM builds the Rust frontend)
 
@@ -86,10 +104,25 @@ source "$HOME/.cargo/env"
 ### 3.3 Clone this repo
 
 ```bash
-git clone https://github.com/yhfgyyf/vllm-deepseek-v4-sm80-sm86-sm89.git
-cd vllm-deepseek-v4-sm80-sm86-sm89
-git checkout sm80-deepseek-v4-flash
+git clone https://github.com/yhfgyyf/vllm-deepseek-v4-sm89.git
+cd vllm-deepseek-v4-sm89
+git fetch https://github.com/fidonan/vllm-deepseek-v4-sm89.git \
+  perf/sm80-long-context-mqa-block-m
+git checkout -B perf-sm80-long-context-mqa-block-m FETCH_HEAD
+git rev-parse HEAD
+uv venv --python 3.12
+source .venv/bin/activate
+uv pip install torch==2.11.0 --index-url https://download.pytorch.org/whl/cu130
 ```
+
+The public head branch above reproduces this change exactly before merge; after merge, use the
+maintainer's final merged branch/tag and commit instead. Pin and record the printed
+commit. The SM80 base branch does not yet contain
+[PR #51](https://github.com/yhfgyyf/vllm-deepseek-v4-sm89/pull/51), which is already
+merged into `main`; synchronize that paged-MQA 64-bit addressing fix before a
+long-context deployment. Its current single commit is
+`3183db2f6c86803cc86d06223000d220e001baf8`; check the target revision with
+`git merge-base --is-ancestor`, review it, and cherry-pick only when absent.
 
 ### 3.4 Build
 
@@ -136,12 +169,25 @@ The branch changes frequently. Prefer source install unless you have built and p
 
 ## 5. Operator smoke test (no full model needed)
 
+Run the repository tests after installation:
+
+```bash
+uv pip install -r requirements/test/cuda.txt \
+  --extra-index-url https://download.pytorch.org/whl/cu130 \
+  --index-strategy unsafe-best-match
+.venv/bin/python test_sm80_ops.py
+.venv/bin/python -m pytest -q tests/v1/attention/test_sm120_deepgemm_fallbacks.py
+```
+
+The final command checks long-sequence `BLOCK_M=16` selection. On SM80 it also
+compares the complete M16 and M64 logits and requires element-wise equality.
+
 ```python
 import torch
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.mla import sparse_mla_env as e
 print("cap:", current_platform.get_device_capability())          # (8, 9)
-print("is_ada_sm89:", e.is_ada_sm89())                            # True
+print("is_ampere_or_ada:", e.is_ampere_or_ada())                 # True on SM8x
 print("triton sparse mla:", e.is_triton_sparse_mla_enabled(torch.device("cuda:0")))  # True
 from vllm.model_executor.layers.sparse_attn_indexer import _sparse_indexer_requires_deep_gemm as r
 print("indexer needs deepgemm (fp8 cache):", r(False))           # False  <- key fix
@@ -151,13 +197,21 @@ print("has_cutedsl:", has_cutedsl())                             # False on SM89
 
 ---
 
-## 6. Deployment (vllm serve)
+## 6. Reproducible deployment
+
+### 6.1 Source route
+
+The following command uses the public DSpark model ID and records no machine path,
+bind address, or credential. Set `TP_SIZE` to the number of GPUs selected by the
+operator.
 
 ```bash
+export MODEL_ID=deepseek-ai/DeepSeek-V4-Flash-DSpark
+export TP_SIZE="${TP_SIZE:?set TP_SIZE to the number of selected GPUs}"
 export VLLM_TRITON_MLA_SPARSE=1
-vllm serve /path/to/DeepSeek-V4-Flash \
+.venv/bin/vllm serve "$MODEL_ID" \
   --served-model-name deepseek-v4-flash \
-  --tensor-parallel-size 4 \
+  --tensor-parallel-size "$TP_SIZE" \
   --kv-cache-dtype fp8_ds_mla \
   --block-size 256 \
   --max-model-len 262144 \
@@ -165,22 +219,188 @@ vllm serve /path/to/DeepSeek-V4-Flash \
   --max-num-seqs 16 \
   --reasoning-parser deepseek_v4 \
   --enable-auto-tool-choice --tool-call-parser deepseek_v4 \
-  --trust-remote-code --port 8000
+  --trust-remote-code
 ```
 
 Startup success markers: `Application startup complete.`, and the log shows `Using 'MARLIN' Mxfp4 MoE backend` / `Using FP8 indexer cache`.
 
+### 6.2 Validated 2×A100 hybrid route
+
+This route is for two 80-GiB A100 GPUs that cannot keep all MoE experts resident
+in GPU memory. The measured runtime was
+[Lvllmds4-x v2.3.9](https://github.com/guqiong96/Lvllmds4-x/releases/tag/lvllmds4-x-v2.3.9).
+The asset is `lvllmds4_x-2.3.9-cp312-cp312-manylinux_2_34_x86_64.whl`, requiring
+x86_64, Python 3.12, and glibc 2.34 or newer. Its SHA-256 is
+`1357dd5e11d060cce973f84563d96bb18c1bd2bd7a4d05f642fe01629ba7ab62`.
+
+```bash
+export LVLLM_REPRO_DIR=.repro/lvllmds4x
+mkdir -p "$LVLLM_REPRO_DIR"
+uv venv --python 3.12 "$LVLLM_REPRO_DIR/.venv"
+export LVLLM_WHEEL=lvllmds4_x-2.3.9-cp312-cp312-manylinux_2_34_x86_64.whl
+export LVLLM_WHEEL_URL=https://github.com/guqiong96/Lvllmds4-x/releases/download/lvllmds4-x-v2.3.9/$LVLLM_WHEEL
+curl -fL "$LVLLM_WHEEL_URL" -o "$LVLLM_REPRO_DIR/$LVLLM_WHEEL"
+printf '%s  %s\n' \
+  1357dd5e11d060cce973f84563d96bb18c1bd2bd7a4d05f642fe01629ba7ab62 \
+  "$LVLLM_REPRO_DIR/$LVLLM_WHEEL" | sha256sum -c -
+uv pip install --python "$LVLLM_REPRO_DIR/.venv/bin/python" \
+  "$LVLLM_REPRO_DIR/$LVLLM_WHEEL"
+```
+
+Complete these four checks before startup:
+
+1. Install and checksum the public wheel in an isolated environment; do not
+   overwrite an existing vLLM environment.
+   `.repro/` is repository-ignored and should be removed after the work; never
+   commit the wheel or environment files.
+2. Apply this branch's `_fp8_mqa_logits_block_m()` M16 change to that isolated
+   runtime. Section 5 tests only validate the source route and cannot prove that
+   the wheel was patched. From outside the repository, use the hybrid interpreter
+   to inspect `vllm.__file__`, the target function source, and its SM80 long-sequence
+   return value, then run an equivalent GPU-equality test. Stop if imports resolve
+   to the source checkout.
+
+   ```bash
+   set -euo pipefail
+   export LVLLM_REPRO_DIR="${LVLLM_REPRO_DIR:-.repro/lvllmds4x}"
+   REPRO_ROOT="$(pwd -P)"
+   CHECK_DIR="$(mktemp -d)"
+   (
+     cd "$CHECK_DIR"
+     "$REPRO_ROOT/$LVLLM_REPRO_DIR/.venv/bin/python" - <<'PY'
+   import inspect
+   import vllm
+   from vllm.models.deepseek_v4.nvidia.ops import sm12x_mqa
+
+   print(vllm.__file__)
+   print(inspect.getsource(sm12x_mqa._fp8_mqa_logits_block_m))
+   assert sm12x_mqa._fp8_mqa_logits_block_m(4096, 16 * 1024 + 1) == 16
+   PY
+     "$REPRO_ROOT/$LVLLM_REPRO_DIR/.venv/bin/python" \
+       "$REPRO_ROOT/benchmarks/kernels/benchmark_sm12x_mqa.py" \
+       --contexts 98304 --repeats 1 --seed 0
+   )
+   rmdir "$CHECK_DIR"
+   ```
+3. Verify that the runtime contains the
+   [paged-MQA 64-bit addressing fix](https://github.com/yhfgyyf/vllm-deepseek-v4-sm89/pull/51)
+   and the upstream vLLM mixed-precision/packed-KV zeroing fixes:
+   [#47574](https://github.com/vllm-project/vllm/pull/47574),
+   [#49623](https://github.com/vllm-project/vllm/pull/49623),
+   [#49704](https://github.com/vllm-project/vllm/pull/49704),
+   [#49903](https://github.com/vllm-project/vllm/pull/49903),
+   [#50276](https://github.com/vllm-project/vllm/pull/50276), and
+   [#52058](https://github.com/vllm-project/vllm/pull/52058).
+   Long-running use should also include the scheduler per-step drain fix
+   [#44490](https://github.com/vllm-project/vllm/pull/44490).
+4. The CPU must be x86_64 with AVX2, the host must provide a NUMA runtime, and
+   the isolated environment's libstdc++ must satisfy the wheel's GLIBCXX ABI.
+   If the uv environment reports a GLIBCXX error, use a host toolchain, compatible
+   container, or Conda environment that satisfies the ABI; do not replace system
+   libraries in place.
+
+Those correctness backports are independent from this performance PR. The measured
+stack used local backports equivalent to these upstream fixes; the links here are
+the recommended upstream set that converged after the benchmark, and that exact
+set was not rerun as one complete end-to-end A/B. Because these cross-version
+backports still require conflict resolution and retesting against the selected
+revision, this section is a validated configuration checklist, not an unattended
+installer. Without these fixes, an isolated kernel experiment is still useful,
+but a long-context run must not be presented as a long-running stability result.
+
+The following is the currently recommended reproduction profile; it is not the
+exact per-row configuration for every historical sample in Section 7.5.
+`GPU_DEVICES` is supplied by the operator after checking both the GPU-interconnect
+topology and CPU/NUMA affinity. The thread and resident-layer values are not
+universal defaults; use them only after checking GPU memory, host memory, and
+bandwidth.
+
+```bash
+export MODEL_ID=deepseek-ai/DeepSeek-V4-Flash-DSpark
+export CUDA_DEVICE_ORDER=PCI_BUS_ID
+export CUDA_VISIBLE_DEVICES="${GPU_DEVICES:?set the selected GPU IDs}"
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export LVLLM_MOE_NUMA_ENABLED=1
+export LK_THREADS=30
+export OMP_NUM_THREADS=30
+export LK_THREAD_BINDING=CPU_CORE
+export LVLLM_GPU_PREFETCH_WINDOW=1
+export LVLLM_GPU_PREFILL_MIN_BATCH_SIZE=256
+export LK_POWER_SAVING=0
+export LVLLM_GPU_RESIDENT_MOE_LAYERS=0-28
+
+.repro/lvllmds4x/.venv/bin/vllm serve "$MODEL_ID" \
+  --served-model-name deepseek-v4-flash \
+  --tensor-parallel-size 2 \
+  --max-model-len 262144 \
+  --gpu-memory-utilization 0.95 \
+  --trust-remote-code \
+  --compilation_config.cudagraph_mode FULL_DECODE_ONLY \
+  --enable-prefix-caching \
+  --enable-chunked-prefill \
+  --max-num-batched-tokens 8192 \
+  --dtype bfloat16 \
+  --max-num-seqs 2 \
+  --enable-auto-tool-choice \
+  --kv-cache-dtype fp8_ds_mla \
+  --block-size 256 \
+  --tokenizer-mode deepseek_v4 \
+  --tool-call-parser deepseek_v4 \
+  --reasoning-parser deepseek_v4 \
+  --default-chat-template-kwargs '{"enable_thinking": true}' \
+  --speculative-config \
+    '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic"}' \
+  --disable-custom-all-reduce
+```
+
+The measured environment set `FLASHINFER_DISABLE_VERSION_CHECK=1`. This bypasses
+a version guard and is not a general default. Set it for this pinned runtime only
+after verifying the wheel release's FlashInfer version and binary ABI.
+
+`LVLLM_*` and `LK_*` are specific to Lvllmds4-x and do not apply to standard
+vLLM. Startup must finish weight loading, KV initialization, sparse-MLA warmup,
+and Triton/CUDA-graph compilation. Do not begin the measured run until the service
+is healthy, no worker has restarted, and both ranks have completed warmup.
+
+### 6.3 Codex reproduction task
+
+The following task can be pasted directly into Codex. It requires Codex to discover
+devices and directories and prohibits writing discovered machine details back to
+the repository:
+
+```text
+Read AGENTS.md and both README files completely before acting.
+Reproduce the SM80 long-context MQA M16 result in an isolated environment.
+
+1. Inspect GPU capability, topology, NUMA layout, free RAM, disk capacity, CUDA,
+   Python, and the currently selected Git revision. Do not change running services.
+2. Choose either the source-only route or the documented Lvllmds4-x hybrid route.
+   Stop and report if the machine cannot hold the model and runtime state.
+3. Pin every repository revision and verify every downloaded artifact checksum.
+4. Verify the paged-MQA int64 addressing fix and every listed packed/mixed-KV
+   zeroing fix before treating a long-context run as a stability test.
+5. Apply only this branch's M16 selector change, then run the focused unit and
+   GPU-equivalence tests. Do not add Router, protocol, API, or service-manager code.
+6. Start the model in the foreground using endpoint and credentials supplied by
+   the operator. Never invent or commit an address, port, username, absolute local
+   path, credential, service name, prompt, or production log.
+7. Warm each new Triton shape with a throwaway unique prefix. Benchmark another
+   unique prefix at concurrency one, verify zero prefix-cache hits, and save the
+   exact commit, parameters, JIT state, token counts, TTFT, and kernel timing.
+8. Return a sanitized report and leave generated machine-specific files untracked.
+```
+
 ---
 
-## 7. Test results (4× RTX 4090)
+## 7. Test results
 
-### 7.1 Inference correctness
+### 7.1 Inference correctness (4× RTX 4090 source route)
 ```
 Q: Introduce the Great Wall in one sentence. (in Chinese)
 A: A coherent, accurate one-sentence answer is returned, finish_reason=stop.
 ```
 
-### 7.2 Max context (KV cache)
+### 7.2 Max context (4× RTX 4090 source route)
 | max-model-len | max-num-seqs | GMU | GPU KV cache | per-request concurrency | startup |
 |---|---|---|---|---|---|
 | 262,144 (256K) | 16 | 0.97 | 972,374 tok | 3.71x | ✅ |
@@ -188,8 +408,6 @@ A: A coherent, accurate one-sentence answer is returned, finish_reason=stop.
 | **1,048,576 (1M)** | 4 | 0.97 | **1,243,644 tok** | 1.19x | ✅ (model arch limit) |
 
 Longest input that completed: **768K (786,000 tokens, prefill ~147 s)**. 1M starts and the kernels run correctly, but a full 1M single-prompt prefill is **impractically slow (>10 min)**. Day-to-day, **128K–256K** is recommended.
-
-Input-length sweep (256K config, all succeeded): 64K (25 s) / 128K (37 s) / 200K (74 s) / 262K (71 s).
 
 ### 7.3 SM80/A800 DSpark decode performance (single concurrency, 1,024 output tokens)
 | input | DSpark decode | no-DSpark decode | decode speedup |
@@ -199,7 +417,106 @@ Input-length sweep (256K config, all succeeded): 64K (25 s) / 128K (37 s) / 200K
 
 The SM80/A800 path is still a test-only adaptation. This table only reports decode-side results; long-context prefill needs separate evaluation.
 
-### 7.4 Tool call (`deepseek_v4` parser)
+### 7.4 SM80/A100 long-context MQA kernel A/B
+
+This is the historical kernel A/B for the patch: same process and input, with each
+`BLOCK_M` compiled separately; one untimed warmup after compilation, followed by
+the median of three CUDA-event timings. `M` varies with `N` to keep the FP32 logits
+workspace near 256 MiB. The fixed shape uses `num_heads=64`, `head_dim=128`; the
+three `M` values are 2,730, 2,048, and 1,724. Inputs are FP8 E4M3 Q/K plus FP32
+scales/weights. The public same-shape reproducer defaults to random seed 0; the
+historical table used a fixed seed derived from each context length, so the script
+validates the trend and numerical equality rather than promising identical
+millisecond values. The lightweight equivalence test in Section 5 does not
+reproduce these timing shapes.
+
+The public reproducer is
+[`benchmarks/kernels/benchmark_sm12x_mqa.py`](benchmarks/kernels/benchmark_sm12x_mqa.py).
+It refuses non-SM80 devices and reports CUDA-event medians plus M16/M64 equality
+for every shape. Spill counts came from the compiled Triton artifact metadata;
+the values in this table are historical compiler-output values, not constants
+across Triton/CUDA releases.
+
+```bash
+.venv/bin/python benchmarks/kernels/benchmark_sm12x_mqa.py \
+  --contexts 98304 131072 155648 \
+  --repeats 3 \
+  --seed 0 \
+  --output-json mqa-kernel-results.json
+```
+
+| raw context | C4-compressed N | M16 | M64 | kernel speedup | M16 / M64 spill |
+|---:|---:|---:|---:|---:|---:|
+| 98,304 | 24,576 | **40.491 ms** | 643.797 ms | **15.90×** | 0 / 5,744 B/thread |
+| 131,072 | 32,768 | **34.065 ms** | 1,003.002 ms | **29.44×** | 0 / 8,272 B/thread |
+| 155,648 | 38,912 | **34.547 ms** | 644.409 ms | **18.65×** | 0 / 5,744 B/thread |
+
+All three complete FP32-logits tensors, each about 256 MiB, satisfy
+`torch.equal(M16, M64)` with no NaN/Inf mismatch. These values are single-kernel
+latencies, **not** TTFT or end-to-end prefill tok/s.
+
+### 7.5 SM80/A100 end-to-end observations
+
+Every row below was actually run at concurrency one. Prefill throughput is
+`prompt tokens / client TTFT`. The formal M16 samples use a fresh token sequence,
+zero prefix-cache hits, and an already-warmed JIT shape.
+
+| context | selector / state | client TTFT | observed prefill |
+|---:|---|---:|---:|
+| 65,536 | original selector already used M16; JIT-hot boundary control | 29.893 s | **2,192.4 tok/s** |
+| 98,304 | original M64 selector; cold prefix | 237.989 s | 413.1 tok/s |
+| 98,304 | M16; first shape/JIT | 105.971 s | 927.6 tok/s |
+| 98,304 | M16; JIT-hot, cold prefix | 54.383 s | **1,807.6 tok/s** |
+| 155,648 | original M64 selector; cold prefix | 730.664 s | 213.0 tok/s |
+| 155,648 | M16; first shape/JIT | 138.660 s | 1,122.5 tok/s |
+| 155,648 | M16; JIT-hot, cold prefix | 110.015 s | **1,414.8 tok/s** |
+
+These end-to-end results are `n=1` runtime observations, not strict same-config
+A/B results. The old baseline used `max-num-batched-tokens=16384` and resident
+layers `0-27`; the M16 samples used `8192`, GMU `0.90`, resident layers `0-28`, and a separate
+compile cache. Raw context 65,536 maps exactly to the C4 16,384 boundary, where the
+old code already selected M16, so it is only a control. No patched 131,072-token
+full-service cold-prefill run was performed; this document gives no end-to-end
+speed or interpolated result for that length.
+
+Do not reuse the measured prompt through the built-in warmup request. First send
+an independent JIT-priming request of the same length with seed A, then start the
+formal one-request run with seed B; disable request warmup and ready check in both
+runs. The saved `input_lens` must match the target length, metrics must report a
+zero cache-hit delta, and the measured request window must contain no new JIT log.
+`input_lens[0] / ttfts[0]` is the client-observed TTFT rate used in this table; it
+is not server `request_prefill_time`.
+
+The example below uses the hybrid route; for the source route, point `BENCH_VLLM`
+to `.venv/bin/vllm`.
+
+```bash
+export BENCH_VLLM=.repro/lvllmds4x/.venv/bin/vllm
+"$BENCH_VLLM" bench serve \
+  --backend openai \
+  --base-url "${BENCH_BASE_URL:?set the operator-provided endpoint}" \
+  --endpoint /v1/completions \
+  --model deepseek-v4-flash \
+  --tokenizer deepseek-ai/DeepSeek-V4-Flash-DSpark \
+  --tokenizer-mode deepseek_v4 \
+  --dataset-name random \
+  --random-input-len "${BENCH_TOKENS:?set the measured input length}" \
+  --random-output-len 32 \
+  --random-range-ratio 0 \
+  --num-prompts 1 \
+  --max-concurrency 1 \
+  --request-rate inf \
+  --num-warmups 0 \
+  --ready-check-timeout-sec 0 \
+  --seed "${BENCH_SEED:?use a seed different from the priming request}" \
+  --temperature 0 \
+  --save-result \
+  --save-detailed \
+  --result-dir "${BENCH_RESULT_DIR:?set an isolated result directory}" \
+  --result-filename measured.json
+```
+
+### 7.6 Tool call (`deepseek_v4` parser)
 ```
 Q: What's Beijing's weather today? Answer in Celsius. (tools=[get_weather])
 → finish_reason: tool_calls
@@ -213,7 +530,18 @@ Q: What's Beijing's weather today? Answer in Celsius. (tools=[get_weather])
 1. **MoE runs on Marlin**: correctness validated, but performance is below native FP4 MMA — the biggest remaining tuning opportunity.
 2. **Performance is not tuned for the 4090**: the fused_moe / scaled_mm tuned configs only cover RTX PRO 6000 / GB10; the 4090 uses default heuristics (the log prints "Performance might be sub-optimal").
 3. **Very long context**: 1M starts but prefill is impractically slow; single requests over 256K take several minutes.
-4. Validated only on 4× RTX 4090; other Ada GPUs (L40/L4, etc.) should work in principle but are untested.
+4. The 4× RTX 4090 source route, 4× A800 DSpark decode, and 2× A100 hybrid route
+   each have the tests explicitly labeled in this document. Other Ada GPUs
+   (L40/L4, etc.) should work in principle but are untested.
+5. **M16 only optimizes prefill:** paged decode does not call this non-paged MQA
+   path. Decode throughput is still determined by long-context attention, MoE
+   offload, and DSpark acceptance.
+6. **Deployment dependency boundary:** this PR does not include the paged-MQA
+   addressing or packed/mixed-KV zeroing backports. Do not claim the full stable
+   environment was reproduced before checking the prerequisites in Section 6.2.
+7. **Benchmark boundary:** the first new shape includes JIT cost, while an exact
+   repeat uses the prefix cache. Neither replaces a formal cold-prefix sample with
+   warmed JIT and zero cache hits.
 
 ---
 

--- a/benchmarks/kernels/benchmark_sm12x_mqa.py
+++ b/benchmarks/kernels/benchmark_sm12x_mqa.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark DeepSeek-V4 direct MQA logits tiles on SM80."""
+
+from __future__ import annotations
+
+import json
+import math
+import statistics
+from pathlib import Path
+
+import torch
+import triton
+
+from vllm.models.deepseek_v4.nvidia.ops import sm12x_mqa
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+NUM_HEADS = 64
+HEAD_DIM = 128
+BLOCK_N = 128
+BLOCK_D = 128
+LOGITS_BUDGET_BYTES = 256 * 1024 * 1024
+DEFAULT_CONTEXTS = (98_304, 131_072, 155_648)
+
+
+def make_inputs(m: int, n: int, seed: int) -> tuple[torch.Tensor, ...]:
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    q = (
+        torch.randn(
+            (m, NUM_HEADS, HEAD_DIM),
+            device="cuda",
+            dtype=torch.float16,
+            generator=generator,
+        )
+        .clamp_(-2.0, 2.0)
+        .to(torch.float8_e4m3fn)
+        .view(torch.uint8)
+    )
+    k = (
+        torch.randn(
+            (n, HEAD_DIM),
+            device="cuda",
+            dtype=torch.float16,
+            generator=generator,
+        )
+        .clamp_(-2.0, 2.0)
+        .to(torch.float8_e4m3fn)
+        .view(torch.uint8)
+    )
+    scale = (
+        torch.rand(n, device="cuda", dtype=torch.float32, generator=generator) * 0.02
+        + 0.01
+    )
+    weights = torch.rand(
+        (m, NUM_HEADS), device="cuda", dtype=torch.float32, generator=generator
+    )
+    weights /= weights.sum(dim=1, keepdim=True)
+    row_starts = torch.zeros(m, device="cuda", dtype=torch.int32)
+    row_ends = torch.full((m,), n, device="cuda", dtype=torch.int32)
+    return q, k, scale, weights, row_starts, row_ends
+
+
+def launch(
+    inputs: tuple[torch.Tensor, ...],
+    logits: torch.Tensor,
+    block_m: int,
+) -> None:
+    q, k, scale, weights, row_starts, row_ends = inputs
+    m, n = logits.shape
+    grid = (math.ceil(m / block_m), math.ceil(n / BLOCK_N))
+    sm12x_mqa._fp8_mqa_logits_kernel[grid](
+        q,
+        k,
+        scale,
+        weights,
+        row_starts,
+        row_ends,
+        logits,
+        m,
+        n,
+        NUM_HEADS,
+        HEAD_DIM,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k.stride(0),
+        k.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        logits.stride(0),
+        logits.stride(1),
+        BLOCK_M=block_m,
+        BLOCK_N=BLOCK_N,
+        BLOCK_D=BLOCK_D,
+        num_warps=4,
+    )
+
+
+def time_kernel(
+    inputs: tuple[torch.Tensor, ...],
+    logits: torch.Tensor,
+    block_m: int,
+    repeats: int,
+) -> tuple[float, list[float]]:
+    for _ in range(2):
+        launch(inputs, logits, block_m)
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(repeats):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        launch(inputs, logits, block_m)
+        end.record()
+        end.synchronize()
+        samples.append(float(start.elapsed_time(end)))
+    return statistics.median(samples), samples
+
+
+def benchmark_context(context: int, repeats: int, seed: int) -> dict[str, object]:
+    n = context // 4
+    m = LOGITS_BUDGET_BYTES // (n * torch.float32.itemsize)
+    inputs = make_inputs(m, n, seed)
+    outputs: dict[int, torch.Tensor] = {}
+    medians: dict[int, float] = {}
+    samples: dict[int, list[float]] = {}
+
+    for block_m in (16, 64):
+        logits = torch.empty((m, n), device="cuda", dtype=torch.float32)
+        median_ms, samples_ms = time_kernel(inputs, logits, block_m, repeats)
+        outputs[block_m] = logits
+        medians[block_m] = median_ms
+        samples[block_m] = samples_ms
+
+    exact_equal = bool(torch.equal(outputs[16], outputs[64]))
+    if not exact_equal:
+        raise AssertionError(f"M16 and M64 logits differ for context {context}")
+
+    return {
+        "context_tokens": context,
+        "compressed_n": n,
+        "num_q_m": m,
+        "num_heads": NUM_HEADS,
+        "head_dim": HEAD_DIM,
+        "logits_bytes": m * n * torch.float32.itemsize,
+        "block_m16": {"median_ms": medians[16], "samples_ms": samples[16]},
+        "block_m64": {"median_ms": medians[64], "samples_ms": samples[64]},
+        "m16_speedup": medians[64] / medians[16],
+        "exact_equal": exact_equal,
+    }
+
+
+def main() -> None:
+    parser = FlexibleArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--contexts", type=int, nargs="+", default=list(DEFAULT_CONTEXTS)
+    )
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (8, 0):
+        raise SystemExit("This benchmark requires an SM80 CUDA device")
+    if args.repeats < 1:
+        parser.error("--repeats must be positive")
+    if any(context <= 0 or context % 4 for context in args.contexts):
+        parser.error("--contexts values must be positive and divisible by 4")
+
+    results = [
+        benchmark_context(context, args.repeats, args.seed) for context in args.contexts
+    ]
+    report = {
+        "kind": "sm80_mqa_kernel_latency",
+        "device": torch.cuda.get_device_name(),
+        "device_capability": torch.cuda.get_device_capability(),
+        "torch_version": torch.__version__,
+        "triton_version": triton.__version__,
+        "cuda_version": torch.version.cuda,
+        "untimed_warmups": 2,
+        "repeats": args.repeats,
+        "seed": args.seed,
+        "results": results,
+    }
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(rendered + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/v1/attention/test_sm120_deepgemm_fallbacks.py
+++ b/tests/v1/attention/test_sm120_deepgemm_fallbacks.py
@@ -158,11 +158,60 @@ def test_sparse_indexer_requires_deep_gemm_for_other_cuda_arches(monkeypatch):
     assert _sparse_indexer_requires_deep_gemm(use_fp4_cache=False)
 
 
-def test_sm120_direct_mqa_logits_block_m_prefers_short_prefill_tile():
-    assert sm12x_mqa._fp8_mqa_logits_block_m(1024, 1024) == 16
-    assert sm12x_mqa._fp8_mqa_logits_block_m(4096, 4096) == 16
-    assert sm12x_mqa._fp8_mqa_logits_block_m(16384, 16384) == 16
-    assert sm12x_mqa._fp8_mqa_logits_block_m(65536, 65536) == 64
+@pytest.mark.parametrize(
+    ("capability", "seq_len_kv", "expected"),
+    [
+        ((8, 0), 16 * 1024, 16),
+        ((8, 0), 16 * 1024 + 1, 16),
+        ((8, 6), 16 * 1024 + 1, 64),
+        ((8, 9), 16 * 1024 + 1, 64),
+        ((12, 0), 16 * 1024 + 1, 64),
+    ],
+)
+def test_sm80_direct_mqa_logits_block_m_avoids_long_prefill_spills(
+    monkeypatch, capability, seq_len_kv, expected
+):
+    monkeypatch.setattr(
+        sm12x_mqa.current_platform,
+        "is_device_capability",
+        lambda requested: requested == capability,
+    )
+
+    assert sm12x_mqa._fp8_mqa_logits_block_m(4096, seq_len_kv) == expected
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (8, 0),
+    reason="SM80 only",
+)
+def test_sm80_long_mqa_block_m16_matches_block_m64(monkeypatch):
+    torch.manual_seed(0)
+    num_q, seq_len_kv, num_heads, head_dim = 17, 16 * 1024 + 128, 64, 128
+    q = (
+        torch.randn((num_q, num_heads, head_dim), device="cuda")
+        .clamp_(-2, 2)
+        .to(torch.float8_e4m3fn)
+    )
+    k = (
+        torch.randn((seq_len_kv, head_dim), device="cuda")
+        .clamp_(-2, 2)
+        .to(torch.float8_e4m3fn)
+    )
+    scale = torch.rand(seq_len_kv, device="cuda", dtype=torch.float32)
+    weights = torch.rand((num_q, num_heads), device="cuda", dtype=torch.float32)
+    row_starts = torch.arange(num_q, device="cuda", dtype=torch.int32)
+    row_ends = torch.full((num_q,), seq_len_kv - 1, device="cuda", dtype=torch.int32)
+
+    monkeypatch.setattr(sm12x_mqa, "_fp8_mqa_logits_block_m", lambda *_: 16)
+    block_m16 = sm12x_mqa.fp8_mqa_logits_triton(
+        q, (k, scale), weights, row_starts, row_ends
+    )
+    monkeypatch.setattr(sm12x_mqa, "_fp8_mqa_logits_block_m", lambda *_: 64)
+    block_m64 = sm12x_mqa.fp8_mqa_logits_triton(
+        q, (k, scale), weights, row_starts, row_ends
+    )
+
+    torch.testing.assert_close(block_m16, block_m64, rtol=0, atol=0)
 
 
 def test_sm120_direct_mqa_logits_block_d_uses_full_indexer_head_tile():

--- a/vllm/models/deepseek_v4/nvidia/ops/sm12x_mqa.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/sm12x_mqa.py
@@ -7,6 +7,7 @@ import torch
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     _e4m3_uint8_to_f32,
 )
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
 
@@ -189,6 +190,9 @@ def fp8_mqa_logits_triton(
 
 
 def _fp8_mqa_logits_block_m(num_q: int, seq_len_kv: int) -> int:
+    # Larger query tiles spill to local memory on SM80 for long sequences.
+    if current_platform.is_device_capability((8, 0)):
+        return 16
     if seq_len_kv <= 16 * 1024:
         return 16
     return 64


### PR DESCRIPTION
## Purpose

On exact SM80 devices, the portable FP8 MQA prefill kernel switched from
`BLOCK_M=16` to `BLOCK_M=64` after the compressed KV sequence exceeded 16K
tokens. For the long-context C4-indexer shapes tested on A100, the M64 kernel
spilled heavily to local memory and caused a sharp prefill slowdown.

This PR keeps M16 for exact SM80 while preserving the existing selector policy
for SM86, SM89, and SM120.

## Scope

This PR contains only the SM80 prefill-kernel change and its reproducibility
material:

- exact-SM80 selector gate;
- selector and numerical-equivalence regressions;
- a same-shape M16/M64 CUDA-event microbenchmark;
- bilingual source and hybrid-deployment guidance;
- measured A100 kernel and end-to-end observations.

It does not add a Router, protocol adapter, service-manager configuration, or
machine-specific deployment data.

The selector change is sufficient to reproduce the M16 kernel behavior. A full
long-running hybrid deployment also requires the runtime/offload stack and the
correctness backports listed in the README; those are deliberately not folded
into this focused performance PR.

This is not a duplicate of #51, which fixes 32-bit paged-MQA block addressing,
or #61, which addresses request-dependent Triton specialization-cache growth.
Neither changes the prefill tile selector.

## Strict kernel benchmark

The benchmark uses one untimed compilation/warm-up phase followed by CUDA-event
timing and reports the median. Each row compares identical inputs and the full
FP32 logits tensors were bitwise equal.

| Raw context | Compressed KV | M16 median | M64 median | Speedup | Spill M16 / M64 |
|---:|---:|---:|---:|---:|---:|
| 98,304 | 24,576 | 40.491 ms | 643.797 ms | 15.90x | 0 / 5,744 B per thread |
| 131,072 | 32,768 | 34.065 ms | 1,003.002 ms | 29.44x | 0 / 8,272 B per thread |
| 155,648 | 38,912 | 34.547 ms | 644.409 ms | 18.65x | 0 / 5,744 B per thread |

## Observational end-to-end validation

These are single-concurrency, prefix-cold measurements. They are published as
observations rather than a strict A/B because the historical baseline and M16
validation profiles differ in batch size, resident-layer count, compilation
cache, and prompt seed.

| Raw context | Selector state | Client-observed TTFT | Prompt tokens / TTFT |
|---:|---|---:|---:|
| 65,536 | boundary control; already M16 before this PR | 29.893 s | 2,192.4 tok/s |
| 98,304 | historical M64 | 237.989 s | 413.1 tok/s |
| 98,304 | M16, JIT-hot unique prefix | 54.383 s | 1,807.6 tok/s |
| 155,648 | historical M64 | 730.664 s | 213.0 tok/s |
| 155,648 | M16, JIT-hot unique prefix | 110.015 s | 1,414.8 tok/s |

No patched 131,072-token full-service result is claimed or interpolated. The
README records the complete measurement boundaries, first-shape JIT samples,
and commands for independent reproduction.

## Validation

- Focused selector tests: 5 passed.
- The CUDA numerical-equivalence case is architecture-gated; it was skipped in
  the final CPU-only documentation environment.
- Ruff lint and formatting checks passed for the kernel, tests, and benchmark.
- `git diff --check` passed.
- README shell snippets and privacy checks passed.

AI assistance was used to inspect the kernel, prepare the patch and benchmark,
and draft the tests and documentation. The submitter reviewed the resulting
changes and measured results.
