### PR TITLE
[Bugfix][Attention] Avoid FlashMLA metadata on unsupported GPUs

### DIFF
--- a/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
+++ b/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
@@ -6,6 +6,7 @@ import sys
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
+import pytest
 import torch
 
 from vllm.config import set_current_vllm_config
@@ -21,6 +22,7 @@ from vllm.models.deepseek_v4.nvidia.flashinfer_sparse import (
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils import flashinfer as fi_utils
 from vllm.v1.attention.backends.mla import flashinfer_mla_sparse as sparse_module
+from vllm.v1.attention.backends.mla import sparse_swa as sparse_swa_module
 from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
     FlashInferMLASparseSM120Backend,
 )
@@ -231,8 +233,6 @@ def test_sm89_dsv4_backend_selects_packed_flashinfer(monkeypatch) -> None:
 
 
 def test_sm89_dsv4_backend_rejects_unpatched_flashinfer(monkeypatch) -> None:
-    import pytest
-
     from vllm.models.deepseek_v4.nvidia import model as dsv4_model
 
     monkeypatch.setattr(
@@ -245,6 +245,53 @@ def test_sm89_dsv4_backend_rejects_unpatched_flashinfer(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="native sparse MLA SM89"):
         dsv4_model._select_dsv4_attn_cls(vllm_config)
+
+
+@pytest.mark.parametrize("flashmla_supported", [False, True])
+def test_dsv4_swa_metadata_uses_only_supported_flashmla(
+    monkeypatch, flashmla_supported: bool
+) -> None:
+    builder = object.__new__(sparse_swa_module.DeepseekSparseSWAMetadataBuilder)
+    builder._layer_types = {"c4a"}
+    metadata_calls: list[object] = []
+
+    monkeypatch.setattr(
+        sparse_swa_module,
+        "is_flashmla_sparse_supported",
+        lambda: (
+            flashmla_supported,
+            None if flashmla_supported else "unsupported",
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(sparse_swa_module.current_platform, "is_rocm", lambda: False)
+    monkeypatch.setattr(sparse_swa_module.current_platform, "is_xpu", lambda: False)
+    monkeypatch.setattr(
+        sparse_swa_module.current_platform,
+        "is_device_capability_family",
+        lambda _: False,
+    )
+
+    def fake_get_mla_metadata():
+        metadata = object()
+        metadata_calls.append(metadata)
+        return metadata, None
+
+    monkeypatch.setattr(
+        sparse_swa_module,
+        "get_mla_metadata",
+        fake_get_mla_metadata,
+    )
+
+    tile_scheduler = builder.build_tile_scheduler(1)
+
+    assert tile_scheduler["swaonly"] is None
+    assert tile_scheduler["c128a"] is None
+    if flashmla_supported:
+        assert tile_scheduler["c4a"] is metadata_calls[0]
+    else:
+        assert tile_scheduler["c4a"] is None
+    assert len(metadata_calls) == int(flashmla_supported)
 
 
 def test_sm120_kernel_block_sizes_are_glm_config_aware() -> None:

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -29,7 +29,11 @@ from vllm.v1.attention.backends.utils import (
     fill_mm_prefix_query_ranges,
     split_decodes_and_prefills,
 )
-from vllm.v1.attention.ops.flashmla import FlashMLASchedMeta, get_mla_metadata
+from vllm.v1.attention.ops.flashmla import (
+    FlashMLASchedMeta,
+    get_mla_metadata,
+    is_flashmla_sparse_supported,
+)
 from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     MLAAttentionSpec,
@@ -746,20 +750,15 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         call of each type. Subsequent same-type calls reuse the plan because
         the tensors (and ``have_initialized``) are populated on the struct.
 
-        Returns all-``None`` when there are no decode tokens this step, so
-        ``_forward_decode`` sees a clean sentinel.
+        Returns all-``None`` when there are no decode tokens or FlashMLA sparse
+        is unsupported, so non-FlashMLA backends see a clean sentinel.
         """
         out: dict[str, FlashMLASchedMeta | None] = {
             _LAYER_TYPE_SWAONLY: None,
             _LAYER_TYPE_C4A: None,
             _LAYER_TYPE_C128A: None,
         }
-        if (
-            num_decode_tokens == 0
-            or current_platform.is_rocm()
-            or current_platform.is_xpu()
-            or current_platform.is_device_capability_family(120)
-        ):
+        if num_decode_tokens == 0 or not is_flashmla_sparse_supported()[0]:
             return out
         for layer_type in self._layer_types:
             # get_mla_metadata() is the official FlashMLA entry point that


### PR DESCRIPTION
## Summary

- Gate DeepSeek V4 SWA tile scheduler metadata on the existing FlashMLA sparse support probe.
- Keep SM89 and SM120 FlashInfer paths from importing unavailable FlashMLA scheduler state.
- Preserve FlashMLA metadata allocation on supported SM90 and SM100 platforms.
- Add regression coverage for both unsupported and supported paths.

## Duplicate-work check

No open PR in this repository or upstream addresses Issue #90 or this SM89 FlashMLA metadata dispatch bug. Upstream PR #38476 and #53055 cover different sparse MLA and fallback work.

## Tests

- `.venv/bin/python -m pytest -p no:cacheprovider tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py -q` — 23 passed.
- `.venv/bin/pre-commit run --files vllm/v1/attention/backends/mla/sparse_swa.py tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py` — passed.
- `git diff --check` — passed.

## Model evaluation

Not run. This change only prevents unsupported scheduler metadata allocation before kernel dispatch and does not modify model weights, numerical kernels, sampling, or output processing. Full-model L20 serving remains the post-merge runtime validation step.

## AI assistance

AI assistance was used for root-cause analysis, implementation, tests, and PR preparation. The complete diff and test evidence were reviewed before submission.

Fixes #90